### PR TITLE
fix parameterEstimares.mi() large DF subsutition if any DFs misssing

### DIFF
--- a/R/pool-estimates.R
+++ b/R/pool-estimates.R
@@ -167,7 +167,7 @@ parameterEstimates.mi <- function(object,
       if (ci)     crit <- qt(1 - (1 - level) / 2, df = df4t)
 
       ## Set obscenely large DF to infinity for prettier printing?
-      if (zstat && output == "text" && any(PE$df > 999.5)) {
+      if (zstat && output == "text" && any(PE$df[free] > 999.5)) {
         PE$df <- ifelse(PE$df > 999, Inf, PE$df)
         infDF <- TRUE # to warn users who would panic
       }


### PR DESCRIPTION
I've implemented the tiny fix suggested by @simongrund1 in https://github.com/TDJorgensen/lavaan.mi/issues/5 and verified that it works. (Seemed about the right complexity for my first pull request ever, sorry if I made any mistakes.)