### PR TITLE
Add mising omit.imps in mi2lavaan

### DIFF
--- a/R/mi2lavaan.R
+++ b/R/mi2lavaan.R
@@ -224,7 +224,7 @@ mi2lavaan <- function(object, omit.imps = c("no.conv","no.se"),
     if (!is.null(PT$est  )) PT$est   <- NULL
     if (!is.null(PT$se   )) PT$se    <- NULL
     ## get pooled estimates
-    FIT@ParTable$est <- coef_lavaan_mi(object, type = "user")
+    FIT@ParTable$est <- coef_lavaan_mi(object, type = "user", omit.imps = omit.imps)
     # PE <- parameterEstimates.mi(object, se = FALSE, omit.imps = omit.imps,
     #                             remove.system.eq = FALSE, remove.eq = FALSE)
     ## merge pooled estimates into parameter table


### PR DESCRIPTION
Fixes the issue (describe via email) that `standardizedSolution.mi` sometimes ignores the `omit.imps` argument, because the argument is not passed on in place in `mi2lavaan`. This pull request simply adds the missing `omit.imps` argument.